### PR TITLE
Frontend Integration

### DIFF
--- a/Models/DTOs/MaterialDetailedDTO.cs
+++ b/Models/DTOs/MaterialDetailedDTO.cs
@@ -14,5 +14,5 @@ public class MaterialDetailedDTO
     public int GenreId {get; set;}
     public GenreDTO Genre {get; set;}
     public DateTime? OutOfCirculationSince {get; set;}
-    public List<CheckoutDTO> Checkouts {get; set;}
+    public List<CheckoutLateFeeDTO> Checkouts {get; set;}
 }

--- a/Program.cs
+++ b/Program.cs
@@ -141,7 +141,43 @@ var CreateDetailedMaterialDTO = (Material m) =>
             Id = m.Genre.Id,
             Name = m.Genre.Name
         },
-        Checkouts = m.Checkouts.Select(c => CreateCheckoutDTO(c)).ToList()
+        Checkouts = m.Checkouts.Select(c => new CheckoutLateFeeDTO()
+        {
+            Id = c.Id,
+            MaterialId = c.MaterialId,
+            PatronId = c.PatronId,
+            CheckoutDate = c.CheckoutDate,
+            ReturnDate = c.ReturnDate,
+            Paid = c.Paid,
+            Material = new MaterialDTO()
+            {
+                Id = m.Id,
+                MaterialName = m.MaterialName,
+                MaterialTypeId = m.MaterialTypeId,
+                GenreId = m.GenreId,
+                OutOfCirculationSince = m.OutOfCirculationSince,
+                MaterialType = new MaterialTypeDTO()
+                {
+                    Id = m.MaterialType.Id,
+                    Name = m.MaterialType.Name,
+                    CheckoutDays = m.MaterialType.CheckoutDays
+                },
+                Genre = new GenreDTO()
+                {
+                    Id = m.Genre.Id,
+                    Name = m.Genre.Name
+                }
+            },
+            Patron = new PatronDTO()
+            {
+                Id = c.Patron.Id,
+                FirstName = c.Patron.FirstName,
+                LastName = c.Patron.LastName,
+                Address = c.Patron.Address,
+                Email = c.Patron.Email,
+                IsActive = c.Patron.IsActive,
+            }
+        }).ToList()
     };
 
     return materialDTO;

--- a/Program.cs
+++ b/Program.cs
@@ -435,7 +435,7 @@ app.MapPut("api/patrons/{id}/deactivate", (LoncotesLibraryDbContext db, int id) 
     foundPatron.IsActive = false; 
     db.SaveChanges();
 
-    return Results.NoContent();
+    return Results.Ok("Deactivated Patron!");
 });
 
 app.MapGet("api/checkouts/overdue", (LoncotesLibraryDbContext db) =>

--- a/Program.cs
+++ b/Program.cs
@@ -421,7 +421,7 @@ app.MapPut("api/patrons/{id}", (LoncotesLibraryDbContext db, int id, PatronUpdat
     foundPatron.Email = update.Email;
     db.SaveChanges();
 
-    return Results.NoContent();
+    return Results.Ok("Patron updated!");
 });
 
 app.MapPut("api/patrons/{id}/deactivate", (LoncotesLibraryDbContext db, int id) =>

--- a/Program.cs
+++ b/Program.cs
@@ -339,7 +339,7 @@ app.MapDelete("api/materials/{id}", (LoncotesLibraryDbContext db, int id) =>
     material.OutOfCirculationSince = DateTime.Now;
     db.SaveChanges();
 
-    return Results.NoContent();
+    return Results.Ok("Material is now out of circulation!");
 });
 
 app.MapGet("api/materialtypes", (LoncotesLibraryDbContext db) =>

--- a/Program.cs
+++ b/Program.cs
@@ -542,7 +542,7 @@ app.MapPut("api/checkouts/{id}/return", (LoncotesLibraryDbContext db, int id) =>
     foundCheckout.ReturnDate = DateTime.Now;
     db.SaveChanges();
 
-    return Results.NoContent();
+    return Results.Ok("Material returned!");
 });
 
 app.MapPut("api/checkouts/{id}/pay", (LoncotesLibraryDbContext db, int id) =>

--- a/Program.cs
+++ b/Program.cs
@@ -452,6 +452,21 @@ app.MapPut("api/patrons/{id}/reactivate", (LoncotesLibraryDbContext db, int id) 
     return Results.Ok("Activated Patron!");
 });
 
+app.MapGet("api/checkouts", (LoncotesLibraryDbContext db) =>
+{
+    List<CheckoutLateFeeDTO> checkoutDTOs = db.Checkouts
+        .Include(c => c.Patron)
+        .Include(c => c.Material)
+        .ThenInclude(m => m.Genre)
+        .Include(c => c.Material)
+        .ThenInclude(m => m.MaterialType)
+        .Where(c => c.ReturnDate == null)
+        .Select(c => CreateDetailedCheckoutDTO(c))
+        .ToList();
+
+    return checkoutDTOs;
+});
+
 app.MapGet("api/checkouts/overdue", (LoncotesLibraryDbContext db) =>
 {
     List<CheckoutLateFeeDTO> checkoutDTOs = db.Checkouts

--- a/Program.cs
+++ b/Program.cs
@@ -438,6 +438,20 @@ app.MapPut("api/patrons/{id}/deactivate", (LoncotesLibraryDbContext db, int id) 
     return Results.Ok("Deactivated Patron!");
 });
 
+app.MapPut("api/patrons/{id}/reactivate", (LoncotesLibraryDbContext db, int id) =>
+{
+    Patron foundPatron = db.Patrons.SingleOrDefault(p => p.Id == id);
+    if (foundPatron == null)
+    {
+        return Results.NotFound();
+    }
+
+    foundPatron.IsActive = true; 
+    db.SaveChanges();
+
+    return Results.Ok("Activated Patron!");
+});
+
 app.MapGet("api/checkouts/overdue", (LoncotesLibraryDbContext db) =>
 {
     List<CheckoutLateFeeDTO> checkoutDTOs = db.Checkouts

--- a/Program.cs
+++ b/Program.cs
@@ -339,7 +339,7 @@ app.MapDelete("api/materials/{id}", (LoncotesLibraryDbContext db, int id) =>
     material.OutOfCirculationSince = DateTime.Now;
     db.SaveChanges();
 
-    return Results.Ok("Material is now out of circulation!");
+    return Results.NoContent();
 });
 
 app.MapGet("api/materialtypes", (LoncotesLibraryDbContext db) =>
@@ -421,7 +421,7 @@ app.MapPut("api/patrons/{id}", (LoncotesLibraryDbContext db, int id, PatronUpdat
     foundPatron.Email = update.Email;
     db.SaveChanges();
 
-    return Results.Ok("Patron updated!");
+    return Results.NoContent();
 });
 
 app.MapPut("api/patrons/{id}/deactivate", (LoncotesLibraryDbContext db, int id) =>
@@ -435,7 +435,7 @@ app.MapPut("api/patrons/{id}/deactivate", (LoncotesLibraryDbContext db, int id) 
     foundPatron.IsActive = false; 
     db.SaveChanges();
 
-    return Results.Ok("Deactivated Patron!");
+    return Results.NoContent();
 });
 
 app.MapPut("api/patrons/{id}/reactivate", (LoncotesLibraryDbContext db, int id) =>
@@ -449,7 +449,7 @@ app.MapPut("api/patrons/{id}/reactivate", (LoncotesLibraryDbContext db, int id) 
     foundPatron.IsActive = true; 
     db.SaveChanges();
 
-    return Results.Ok("Activated Patron!");
+    return Results.NoContent();
 });
 
 app.MapGet("api/checkouts", (LoncotesLibraryDbContext db) =>
@@ -557,7 +557,7 @@ app.MapPut("api/checkouts/{id}/return", (LoncotesLibraryDbContext db, int id) =>
     foundCheckout.ReturnDate = DateTime.Now;
     db.SaveChanges();
 
-    return Results.Ok("Material returned!");
+    return Results.NoContent();
 });
 
 app.MapPut("api/checkouts/{id}/pay", (LoncotesLibraryDbContext db, int id) =>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7288;http://localhost:5190",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
### Purpose
To let users reactivate non-active Patrons, get all non-returned Checkouts, and see all late fees attached to a Material. Also updates 

### Files Changed
- Updated the Checkouts property to be a list of CheckoutLateFeeDTOs in `MaterialDetailedDTO.cs`
- Updated the ports used in `launchSettings.json`
- Updated logic used for creating the list of Checkouts in CreateDetailedMaterialDTO method, added PUT endpoint for reactivating a Patron, and added a GET endpoint that returns all unreturned Checkouts in `Program.cs`

### To Test
Fetch, and run the following commands in order
```
dotnet ef migrations remove
```
```
dotnet ef migrations add InitialCreate
```
```
dotnet ef database update
```
```
dotnet watch run --launch-profile https
```
Then confirm the following
- GET endpoint `api/materials/{id}` returns the appropriate Material with its Material Type and Genre, along with all related Checkouts and their late fees (if applicable)
- GET endpoint `api/checkouts` returns all Checkouts that have not been returned
- PUT endpoint `api/patrons/{id}/reactivate` sets the "IsActive" property of the appropriate Patron to "true"